### PR TITLE
Allow AVS options to choose required address fields

### DIFF
--- a/lib/Moneris.php
+++ b/lib/Moneris.php
@@ -45,7 +45,11 @@ class Moneris
 	 * 			- environment string
 	 * 			- require_cvd bool
 	 * 			- require_avs bool
+	 * 			- require_avs_street_number bool
+	 * 			- require_avs_street_name bool
+	 * 			- require_avs_zipcode bool
 	 * 			- avs_codes array
+	 * @throws Moneris_Exception
 	 * @return Moneris_Gateway
 	 */
 	static public function create(array $params)
@@ -63,8 +67,21 @@ class Moneris
 		if (isset($params['cvd_codes']))
 			$gateway->successful_cvd_codes($params['cvd_codes']);
 
-		if (isset($params['require_avs']))
+		if (isset($params['require_avs'])) {
 			$gateway->require_avs((bool) $params['require_avs']);
+
+			$gateway->require_avs_params(
+				array_merge(
+					array_map(function ($param) use ($params) {
+						return array($param => isset($params[$param]) ? (bool) $params[$param] : true);
+					}, array(
+						'require_avs_street_number',
+						'require_avs_street_name',
+						'require_avs_zipcode',
+					))
+				)
+			);
+		}
 
 		if (isset($params['avs_codes']))
 			$gateway->successful_avs_codes($params['avs_codes']);

--- a/lib/Moneris/Gateway.php
+++ b/lib/Moneris/Gateway.php
@@ -11,6 +11,12 @@ class Moneris_Gateway
 
 	protected $_require_avs = false;
 
+	protected $_require_avs_street_number = false;
+
+	protected $_require_avs_street_name = false;
+
+	protected $_require_avs_zipcode = false;
+
 	/**
 	 * Codes that we're willing to accept for AVS.
 	 * @var array
@@ -150,6 +156,36 @@ class Moneris_Gateway
 	public function check_avs()
 	{
 		return $this->_require_avs;
+	}
+
+	/**
+	 * Must AVS street number match?
+	 *
+	 * @return bool
+	 */
+	public function check_avs_street_number()
+	{
+		return $this->_require_avs_street_number;
+	}
+
+	/**
+	 * Must AVS street name match?
+	 *
+	 * @return bool
+	 */
+	public function check_avs_street_name()
+	{
+		return $this->_require_avs_street_name;
+	}
+
+	/**
+	 * Must AVS zipcode match?
+	 *
+	 * @return bool
+	 */
+	public function check_avs_zipcode()
+	{
+		return $this->_require_avs_zipcode;
 	}
 
 	/**
@@ -312,6 +348,22 @@ class Moneris_Gateway
 	public function require_avs($require_it = true)
 	{
 		$this->_require_avs = $require_it;
+		return $this;
+	}
+
+	/**
+	 * Require specific address verification.
+	 *
+	 * @param array $params
+	 * @return Moneris_Gateway Fluid interface
+	 */
+	public function require_avs_params($params = array())
+	{
+		foreach ($params as $param => $require_it) {
+			if (property_exists($this, '_' . $param) && preg_match('/^require_avs_/', $param)) {
+				$this->{'_' . $param} = $require_it;
+			}
+		}
 		return $this;
 	}
 

--- a/lib/Moneris/Transaction.php
+++ b/lib/Moneris/Transaction.php
@@ -33,6 +33,8 @@ class Moneris_Transaction
 
 	/**
 	 * @param Moneris_Gateway $gateway
+	 * @param array $params
+	 * @param bool $prepare_params
 	 */
 	public function __construct(Moneris_Gateway $gateway, array $params = array(), $prepare_params = true)
 	{
@@ -80,9 +82,14 @@ class Moneris_Transaction
 
 					if ($this->gateway()->check_avs()) {
 
-						if (! isset($params['avs_street_number'])) $errors[] = 'Street number not provided';
-						if (! isset($params['avs_street_name'])) $errors[] = 'Street name not provided';
-						if (! isset($params['avs_zipcode'])) $errors[] = 'Zip/postal code not provided';
+						if ($this->gateway()->check_avs_street_number() && ! isset($params['avs_street_number']))
+							$errors[] = 'Street number not provided';
+
+						if ($this->gateway()->check_avs_street_name() && ! isset($params['avs_street_name']))
+							$errors[] = 'Street name not provided';
+
+						if ($this->gateway()->check_avs_zipcode() && ! isset($params['avs_zipcode']))
+							$errors[] = 'Zip/postal code not provided';
 
 						//@TODO email is Amex/JCB only...
 						//if (! isset($params['avs_email'])) $errors[] = 'Email not provided';


### PR DESCRIPTION
Boolean options passable to the gateway:

* `require_avs_street_number`
* `require_avs_street_name`
* `require_avs_zipcode`

All three are implicitly `true` if `[require_avs => true]` is passed and these keys aren't found in the options array.